### PR TITLE
Adds support for Ruby 2

### DIFF
--- a/lib/sycl.rb
+++ b/lib/sycl.rb
@@ -1,7 +1,17 @@
 # = sycl.rb - Simple YAML Configuration Library
 #
+# Sycl is a gem that makes using YAML[http://yaml.org/] for
+# configuration files convenient and easy. Hashes and arrays made from
+# parsing YAML via Sycl get helper methods that provide simple and natural
+# syntax for querying and setting values. YAML output through Sycl is
+# sorted, so configuration file versions can be compared consistently, and
+# Sycl has hooks to add output styles, so your configuration files stay
+# easy for humans to read and edit, even after being parsed and
+# re-emitted.
+#
 # For more details, visit the
 # {Sycl GitHub page}[https://github.com/groupon/sycl/"target="_parent].
+# = sycl.rb - Simple YAML Configuration Library
 #
 # == License
 #
@@ -35,21 +45,15 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-require 'yaml'
+# sycl relies on the 'syck' YAML parser. Beginning with Ruby 2, syck
+# was removed from Ruby'd stdlib. This logic ensures the correct yaml
+# parser gets loaded if Rubies >= 2 are present.
 
-# = sycl.rb - Simple YAML Configuration Library
-#
-# Sycl is a gem that makes using YAML[http://yaml.org/] for
-# configuration files convenient and easy. Hashes and arrays made from
-# parsing YAML via Sycl get helper methods that provide simple and natural
-# syntax for querying and setting values. YAML output through Sycl is
-# sorted, so configuration file versions can be compared consistently, and
-# Sycl has hooks to add output styles, so your configuration files stay
-# easy for humans to read and edit, even after being parsed and
-# re-emitted.
-#
-# For more details, visit the
-# {Sycl GitHub page}[https://github.com/groupon/sycl/"target="_parent].
+if RUBY_VERSION.to_i >= 2
+  require 'syck'
+else
+  require 'yaml'
+end
 
 module Sycl
 

--- a/sycl.gemspec
+++ b/sycl.gemspec
@@ -33,8 +33,8 @@
 
 Gem::Specification.new do |s|
   s.name        = 'sycl'
-  s.version     = '1.5'
-  s.date        = '2013-07-18'
+  s.version     = '1.6'
+  s.date        = '2015-12-14'
   s.summary     = 'Simple YAML Config Library'
   s.description =
    'This library makes using YAML for configuration files convenient and easy.'
@@ -44,4 +44,5 @@ Gem::Specification.new do |s|
   s.executables << 'sycl'
   s.homepage    = 'https://github.com/groupon/sycl'
   s.license     = 'New-BSD'
+  s.requirements = 'syck must be the default YAML parsing library. For Rubies >= 2.0, the "syck" gem must be available'
 end


### PR DESCRIPTION
The reason we need to conditionally require the `syck` gem is because in Rubies >= 2, the `syck` YAML engine was removed.  In the case where Ruby 2 is being used, the `yaml` gem should not be required since it sets the YAML constant. Instead, require the `syck` gem, which also sets the YAML engine, but uses the `syck` library instead of `Psych`.
